### PR TITLE
FIX: local storage not getting cleared after checkout

### DIFF
--- a/src/components/CartProductList/index.tsx
+++ b/src/components/CartProductList/index.tsx
@@ -44,6 +44,7 @@ const CartProductList = () => {
     })
 
     setCartProducts([])
+    clearLocalStorage()
   }
 
   return (


### PR DESCRIPTION
Added `clearLocalStorage()` at the end of the `checkout` function